### PR TITLE
Allow per-child overrides of ReadDirState in process_read_dir

### DIFF
--- a/src/core/dir_entry_iter.rs
+++ b/src/core/dir_entry_iter.rs
@@ -79,9 +79,9 @@ impl<C: ClientState> Iterator for DirEntryIter<C> {
                     Ok(dir_entry) => dir_entry,
                     Err(err) => return Some(Err(err)),
                 };
-                // 2.2 If dir_entry has a read_children_path means we need to read a new
+                // 2.2 If dir_entry has a read_children means we need to read a new
                 // directory and push those results onto read_dir_results_stack
-                if dir_entry.read_children_path.is_some() {
+                if let Some(ref mut read_children) = dir_entry.read_children {
                     let iter = match self.read_dir_iter.as_mut().ok_or_else(Error::busy) {
                         Ok(iter) => iter,
                         Err(err) => return Some(Err(err)),
@@ -89,7 +89,7 @@ impl<C: ClientState> Iterator for DirEntryIter<C> {
                     if let Err(err) =
                         Self::push_next_read_dir_results(iter, &mut self.read_dir_results_stack)
                     {
-                        dir_entry.read_children_error = Some(err);
+                        read_children.error = Some(err);
                     }
                 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -4,6 +4,7 @@ mod error;
 mod index_path;
 mod ordered;
 mod ordered_queue;
+mod read_children;
 mod read_dir;
 mod read_dir_iter;
 mod read_dir_spec;
@@ -23,6 +24,7 @@ use run_context::*;
 pub use dir_entry::DirEntry;
 pub use dir_entry_iter::DirEntryIter;
 pub use error::Error;
+pub use read_children::ReadChildren;
 pub use read_dir::ReadDir;
 pub use read_dir_spec::ReadDirSpec;
 

--- a/src/core/read_children.rs
+++ b/src/core/read_children.rs
@@ -1,0 +1,33 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::{ClientState, Error};
+
+// A reduced, but public, version of ReadDirSpec
+pub struct ReadChildren<C: ClientState> {
+    /// Path that will be used to read child entries. This is
+    /// automatically set for directories.
+    pub(crate) path: Arc<Path>,
+    /// If the resulting `fs::read_dir` generates an error
+    /// then that error is stored here.
+    pub(crate) error: Option<Error>,
+    /// Use this to customize the ReadDirState passed to the next
+    /// process_read_dir.
+    /// If None, will clone the previous ReadDirState after the parent
+    /// call to process_read_dir.
+    pub client_read_state: Option<C::ReadDirState>,
+}
+
+impl<C: ClientState> ReadChildren<C> {
+    pub(crate) fn new(path: &Path) -> Self {
+        Self {
+            path: Arc::from(path),
+            error: None,
+            client_read_state: None,
+        }
+    }
+
+    pub fn error(&self) -> Option<&Error> {
+        self.error.as_ref()
+    }
+}

--- a/src/core/read_dir_spec.rs
+++ b/src/core/read_dir_spec.rs
@@ -14,7 +14,7 @@ use crate::ClientState;
 #[derive(Debug)]
 pub struct ReadDirSpec<C: ClientState> {
     /// Depth of the directory to read relative to root of walk.
-    pub depth: usize,
+    pub(crate) depth: usize,
     /// Path of the the directory to read.
     pub path: Arc<Path>,
     /// Client branch state that was set in the

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,7 @@
 //!         children.iter_mut().for_each(|dir_entry_result| {
 //!             if let Ok(dir_entry) = dir_entry_result {
 //!                 if dir_entry.depth == 2 {
-//!                     dir_entry.read_children_path = None;
+//!                     dir_entry.read_children = None;
 //!                 }
 //!             }
 //!         });
@@ -125,7 +125,7 @@ use std::sync::Arc;
 
 use crate::core::{ReadDir, ReadDirSpec};
 
-pub use crate::core::{DirEntry, DirEntryIter, Error};
+pub use crate::core::{DirEntry, DirEntryIter, ReadChildren, Error};
 pub use rayon;
 
 /// Builder for walking a directory.
@@ -336,8 +336,8 @@ impl<C: ClientState> WalkDirGeneric<C> {
 
     /// A callback function to process (sort/filter/skip/state) each directory
     /// of entries before they are yielded. Modify the given array to
-    /// sort/filter entries. Use [`entry.read_children_path =
-    /// None`](struct.DirEntry.html#field.read_children_path) to yield a
+    /// sort/filter entries. Use [`entry.read_children =
+    /// None`](struct.DirEntry.html#field.read_children) to yield a
     /// directory entry but skip reading its contents. Use
     /// [`entry.client_state`](struct.DirEntry.html#field.client_state)
     /// to store custom state with an entry.
@@ -374,7 +374,7 @@ fn process_dir_entry_result<C: ClientState>(
                 let metadata = fs::metadata(dir_entry.path())
                     .map_err(|err| Error::from_path(0, dir_entry.path(), err))?;
                 if metadata.file_type().is_dir() {
-                    dir_entry.read_children_path = Some(Arc::from(dir_entry.path()));
+                    dir_entry.read_children = Some(ReadChildren::new(&dir_entry.path()));
                 }
             }
 


### PR DESCRIPTION
process_read_dir can be used to set the next read_dir_state in children.  The default mechanism (reusing the read_dir_state after process_read_dir modifies it) still works.  read_children_path and read_children_error are replaced by a read_children: ReadChildren field, which is basically a public version of ReadDirSpec, and also allows setting an optional ReadDirState.

Fixes https://github.com/Byron/jwalk/issues/38.